### PR TITLE
chore: set edge runtime for delete-user API route

### DIFF
--- a/src/app/api/admin/delete-user/route.ts
+++ b/src/app/api/admin/delete-user/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from "next/server"
 import { supabaseAdmin } from "@/lib/supabase-admin"
 
+export const runtime = "edge"
+
 export async function POST(request: Request) {
   try {
     const { emails } = await request.json()


### PR DESCRIPTION
Adds `export const runtime = 'edge'` to `src/app/api/admin/delete-user/route.ts` so the API route is compatible with Cloudflare Pages deployment.